### PR TITLE
fix: replace 4 bare excepts with except Exception

### DIFF
--- a/evaluation/robotwin/eval_polict_client_openpi.py
+++ b/evaluation/robotwin/eval_polict_client_openpi.py
@@ -265,7 +265,7 @@ def class_decorator(task_name):
     try:
         env_class = getattr(envs_module, task_name)
         env_instance = env_class()
-    except:
+    except Exception:
         raise SystemExit("No Task")
     return env_instance
 
@@ -680,7 +680,7 @@ def parse_args_and_config():
             value = pairs[i + 1]
             try:
                 value = eval(value)
-            except:
+            except Exception:
                 pass
             override_dict[key] = value
         return override_dict

--- a/evaluation/robotwin/test_render.py
+++ b/evaluation/robotwin/test_render.py
@@ -49,7 +49,7 @@ class Sapien_TEST(gym.Env):
         try:
             self.setup_scene()
             print("\033[32m" + "Render Well" + "\033[0m")
-        except:
+        except Exception:
             print("\033[31m" + "Render Error" + "\033[0m")
             exit()
 

--- a/wan_va/modules/model.py
+++ b/wan_va/modules/model.py
@@ -28,7 +28,7 @@ from functools import partial
 
 try:
     from flash_attn_interface import flash_attn_func
-except:
+except Exception:
     from flash_attn import flash_attn_func
 
 __all__ = ['WanTransformer3DModel']


### PR DESCRIPTION
Replace 4 bare `except:` with `except Exception:`. Bare `except:` catches `KeyboardInterrupt` and `SystemExit`, masking real errors.