### PR TITLE
fix: discover wan_va package for installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,11 +43,8 @@ huggingface = "https://github.com/Robbyant"
 modelscope = "https://github.com/Robbyant"
 discord = "https://github.com/Robbyant"
 
-[tool.setuptools]
-packages = ["lingbot_va"]
-
-[tool.setuptools.package-data]
-"lingbot_va" = ["**/*.py"]
+[tool.setuptools.packages.find]
+include = ["wan_va*"]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Description

Updates the setuptools package discovery configuration so editable and regular installs discover the actual `wan_va` package tree.

This keeps the published project name (`LingBot_VA`) unchanged while fixing the Python package path used during build metadata generation. Existing source-tree imports such as `python -m wan_va...` continue to use the same module path.

## Related Issue

No dedicated issue found. This was reproducible from the current `main` branch during install smoke testing.

## Motivation and Context

`pyproject.toml` currently lists `packages = ["lingbot_va"]`, but the repository contains `wan_va/`. As a result, `pip install -e . --no-deps --dry-run` fails before dependency installation with:

```text
error: package directory 'lingbot_va' does not exist
```

Using setuptools package discovery for `wan_va*` makes the install metadata match the repository layout and includes subpackages under `wan_va`.

## How Has This Been / Can This Be Tested?

Environment: WSL2 Ubuntu2204, Python 3.10.12 venv at `/home/Travor/venvs/starvla-332`.

```bash
python -m pip install -e . --no-deps --dry-run
```

Result:

```text
Would install LingBot_VA-0.0.0
```

Also ran:

```bash
git diff --check origin/main...HEAD
```

## Checklist

- [x] Keeps the public project name unchanged.
- [x] Discovers `wan_va` and nested `wan_va.*` packages.
- [x] Does not change runtime dependencies or model code.
