### PR TITLE
docs: clarify PyTorch environment baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ https://github.com/user-attachments/assets/cec7b7a6-953b-4fa4-8f1a-47efc1fce547
 - [Model Download](#-model-download)
 - [Quick Start](#️-quick-start)
   - [Installation](#installation)
+    - [Environment Compatibility Notes](#environment-compatibility-notes)
   - [attn_mode Configuration](#️-important-attn_mode-configuration)
   - [Deploying LingBot-VA for Inference](#deploying-lingbot-va-for-inference)
     - [Evaluation on RoboTwin-2.0](#evaluation-on-robotwin-20)
@@ -93,6 +94,42 @@ pip install torch==2.9.0 torchvision==0.24.0 torchaudio==2.9.0 --index-url https
 pip install websockets einops diffusers==0.36.0 transformers==4.55.2 accelerate msgpack opencv-python matplotlib ftfy easydict
 pip install flash-attn --no-build-isolation
 ```
+
+### Environment Compatibility Notes
+
+The commands above are the recommended baseline for full LingBot-VA
+training, inference, and evaluation runs. PyTorch 2.9.0 with CUDA 12.6 is
+used because the training path depends on PyTorch FlexAttention and the
+inference path depends on attention kernels that are sensitive to the
+PyTorch, CUDA, and `flash-attn` combination.
+
+Other PyTorch builds may be sufficient for lightweight utilities or source
+inspection, but they are not validated as full training/evaluation
+environments. Local smoke checks on Python 3.10-3.13 with PyTorch 2.7,
+2.10, and 2.11 verified only that selected source files compile and
+`torch.nn.attention.flex_attention` can be imported. These checks do not
+validate checkpoint loading, `flash-attn` kernels, RoboTwin/LIBERO
+evaluation, or post-training stability.
+
+| Environment | Status |
+|---|---|
+| Python 3.10.16 + PyTorch 2.9.0 + CUDA 12.6 + `flash-attn` | Recommended baseline for full training/evaluation |
+| Python 3.10-3.13 + PyTorch 2.7/2.10/2.11 | Lightweight source/import smoke only; not documented as supported for full runs |
+| Environments without `flash-attn` | Not sufficient for the flash-attention inference path |
+| PyTorch builds without FlexAttention | Not sufficient for the documented training path |
+
+If you intentionally use a different PyTorch/CUDA pair, please first verify
+the core runtime and attention dependencies:
+
+```bash
+python -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+python -c "from torch.nn.attention.flex_attention import flex_attention; print('flex_attention ok')"
+python -c "import flash_attn; print('flash_attn ok')"
+```
+
+For full model runs, keep the `requirements.txt` / installation commands
+in sync and run a small task-specific smoke test before launching a long
+RoboTwin or LIBERO job.
 
 
 ## ⚠️ Important: `attn_mode` Configuration


### PR DESCRIPTION
## Description

Adds a short environment compatibility note to the installation section explaining that the documented PyTorch 2.9.0 + CUDA 12.6 setup is the recommended full-run baseline.

The note keeps compatibility conservative: other PyTorch/CUDA pairs may be useful for lightweight inspection, but they are not documented as validated training/evaluation environments.

## Related Issue

Resolves Robbyant/lingbot-va#89

## Motivation and Context

Users have asked whether PyTorch 2.9.0 is mandatory and whether other versions are compatible. The current README lists exact installation commands but does not explain why that baseline matters.

This documentation clarifies that full runs depend on version-sensitive attention paths, including PyTorch FlexAttention for training and `flash-attn` for inference/evaluation.

## How Has This Been / Can This Be Tested?

Environment: WSL2 Ubuntu2204, Python 3.10.12 venv at `/home/Travor/venvs/starvla-332`.

```bash
python -m py_compile wan_va/configs/*.py wan_va/utils/scheduler.py wan_va/utils/sever_utils.py wan_va/wan_va_server.py wan_va/train.py
```

Also ran:

```bash
git diff --check origin/main...HEAD
```

## Checklist

- [x] Documents PyTorch 2.9.0 + CUDA 12.6 as the recommended baseline.
- [x] Avoids claiming unvalidated support for older/newer PyTorch builds.
- [x] Adds quick runtime checks for `torch` and `flash_attn`.
