### PR TITLE
Fix FlexAttention cross-attention masks for dynamic text lengths

### DIFF
--- a/wan_va/modules/model.py
+++ b/wan_va/modules/model.py
@@ -95,6 +95,7 @@ class FlexAttnFunc(nn.Module):
     def init_mask(
         latent_shape, 
         action_shape, 
+        text_sequence_length,
         padded_length, 
         chunk_size,
         window_size,
@@ -133,7 +134,9 @@ class FlexAttnFunc(nn.Module):
             )
         FlexAttnFunc.attention_mask = block_mask
 
-        text_seq_ids = torch.arange(B)[:, None].expand(-1, 512).flatten()
+        text_seq_ids = torch.arange(B)[:, None].expand(
+            -1, text_sequence_length
+        ).flatten()
         mask_mod_cross = FlexAttnFunc._get_cross_mask_mod(seq_ids.long().to(device), text_seq_ids.long().to(device))
         block_mask_cross = FlexAttnFunc.compiled_create_block_mask(
                 mask_mod_cross, 1, 1, len(seq_ids), len(text_seq_ids), device=device, _compile=True
@@ -712,6 +715,7 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin):
         latent_hidden_states = self._input_embed(latent_dict['noisy_latents'], input_type='latent').flatten(0, 1)[None]
         action_hidden_states = self._input_embed(action_dict['noisy_latents'], input_type='action').flatten(0, 1)[None]
         text_hidden_states = self._input_embed(latent_dict["text_emb"], input_type='text')
+        text_sequence_length = text_hidden_states.shape[1]
 
         text_hidden_states = text_hidden_states.flatten(0, 1)[None]
 
@@ -764,6 +768,7 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin):
 
         FlexAttnFunc.init_mask(latent_dict['noisy_latents'].shape, 
                                action_dict['noisy_latents'].shape, 
+                               text_sequence_length,
                                padded_length, 
                                input_dict["chunk_size"],
                                window_size=input_dict['window_size'],


### PR DESCRIPTION
## Summary

- derive the per-sample text sequence length from the projected text embeddings
- pass that length into `FlexAttnFunc.init_mask`
- build the cross-attention sequence IDs from the runtime length instead of a fixed 512 tokens

## Root cause

During post-training, text embeddings are flattened from `[B, L, C]` to `[1, B * L, C]` before cross-attention. The FlexAttention cross mask was always built for `B * 512` key/value tokens, so any embedding length other than 512 produced a mask/KV shape mismatch.

This keeps the existing per-sample masking semantics while making the mask length match the actual projected text sequence.

Fixes #82.

## Validation

- NVIDIA GeForce RTX 5090 (compute capability 12.0)
- PyTorch 2.9.0+cu128 and Triton 3.5.0
- reproduced the old behavior with `B=2`, `L=20`: mask shape `(1, 1, 256, 1024)` rejected runtime `kv_len=40`
- validated the patched `FlexAttnFunc` with `B=2`, `L=20`: mask shape `(1, 1, 256, 40)`, BF16 output shape `(1, 256, 2, 64)`, all values finite
- `python -m py_compile wan_va/modules/model.py`
- `git diff --check`
